### PR TITLE
Indexer crash fix

### DIFF
--- a/launch_nias.rb
+++ b/launch_nias.rb
@@ -37,7 +37,6 @@ def launch
   ssf_services = [
                 {:name => 'cons-prod-privacyfilter.rb', :options  => ''},
 		#{:name => 'filtered_client.rb', :options => '-p 1234'},
-                # {:name => 'cons-prod-sif-ingest-unvalidate.rb', :options => ''},
                 {:name =>'cons-prod-sif-ingest-validate.rb', :options => ''},
                 {:name =>'cons-prod-sif-ingest.rb', :options => ''}
               ]

--- a/sms/services/cons-sms-indexer.rb
+++ b/sms/services/cons-sms-indexer.rb
@@ -55,7 +55,7 @@ loop do
 
       		idx_hash = JSON.parse( m.value )
 
-      		puts "\n\nMessage : - #{idx_hash.inspect}\n\n"
+      		# puts "\n\nIndexer Message : - #{idx_hash.inspect}\n\n"
 
         	# no responses needed from redis so pipeline for speed
     		  @redis.pipelined do
@@ -66,12 +66,12 @@ loop do
       				
       				@redis.sadd idx_hash['id'], idx_hash['links'] unless idx_hash['links'].empty?
 
-				idx_hash['otherids'].each do |key, value|
-					@redis.hset value, key, idx_hash['id']
-				end
+      				idx_hash['otherids'].each do |key, value|
+      					@redis.hset "oid:#{value}", key, idx_hash['id']
+      				end
 
-				# then add id to sets for links
-				idx_hash['links'].each do | link |
+      				# then add id to sets for links
+      				idx_hash['links'].each do | link |
                   			refs = []
                   			refs = idx_hash['links'].reject { |n| n == link } # can ignore self-links
                   			refs << idx_hash['id']


### PR DESCRIPTION
Namespace otherid hash keys with ‘oid:’ to prevent type collisions in
Redis.

Actually caused by test data from HITS re-using refid guids as localis
elsewhere in unrelated objects!
