### PR TITLE
Updates to graphs & OneRoster handling

### DIFF
--- a/launch_nias.rb
+++ b/launch_nias.rb
@@ -56,8 +56,8 @@ def launch
                   'cons-prod-sif-parser.rb',
                   'cons-sms-indexer.rb',
                   'cons-sms-storage.rb',
-	              'cons-oneroster-sms-storage.rb', 
-	              'cons-prod-oneroster-parser.rb'
+                  'cons-oneroster-sms-storage.rb', 
+                  'cons-prod-oneroster-parser.rb'
                 ]
 
   sms_services.each_with_index do | service, i |

--- a/sms/oneroster_sif_merge.rb
+++ b/sms/oneroster_sif_merge.rb
@@ -1,6 +1,7 @@
-# prod-oneroster-sif-merge-ids.rb
+# oneroster_sif_merge.rb
 
-# Script which reviews the local IDs in SIF records and OneRosters in Redis that constitute a match,
+
+# Class which reviews the local IDs in SIF records and OneRosters in Redis that constitute a match,
 # and then constructs tuples requesting that the corresponding GUIDs  be  merged as equivalent
 # 
 # the result is always a tuple structure of the form:
@@ -15,42 +16,42 @@ require 'poseidon'
 require 'hashids'
 require 'redis'
 
-@outbound = 'sms.indexer'
-
-@idgen = Hashids.new( 'nsip random temp uid' )
-
-@redis = Redis.new(:url => 'redis://localhost:6381', :driver => :hiredis)
-
-@servicename = 'prod-oneroster-sif-merge-ids'
-
-# set up producer pool - busier the broker the better for speed
-producers = []
-(1..10).each do | i |
-        p = Poseidon::Producer.new(["localhost:9092"], "prod-oneroster-sif-merge-ids", {:partitioner => Proc.new { |key, partition_count| 0 } })
-        producers << p
-end
-@pool = producers.cycle
 
 
-cursor = -1
-outbound_messages = []
+class OneRosterSifMerge
 
-loop do
 
-  begin
-               # create 'empty' index tuple
+	def initialize
+		@outbound = 'sms.indexer'
+		@idgen = Hashids.new( 'nsip random temp uid' )
+		@redis = Redis.new(:url => 'redis://localhost:6381', :driver => :hiredis)
+		@servicename = 'prod-oneroster-sif-merge-ids'
+
+		# set up producer pool - busier the broker the better for speed
+		producers = []
+		(1..10).each do | i |
+		        p = Poseidon::Producer.new(["localhost:9092"], @servicename, {:partitioner => Proc.new { |key, partition_count| 0 } })
+		        producers << p
+		end
+		@pool = producers.cycle
+	end
+
+	def merge_ids
+
+		begin
+
+			outbound_messages = []
+
+			otherids = @redis.smembers 'other:ids'
+
+			otherids.each do | x |
+               	
+               	# create 'empty' index tuple
                 idx = { :type => nil, :id => @idgen.encode( rand(1...999) ), :otherids => {}, :links => [], :equivalentids => [], :label => nil}    
 
-		if(cursor != 0) then
-			cursor = 0 if cursor == -1
-			idscan = @redis.sscan 'other:ids', cursor
-	
-			puts "Read #{idscan[1].length} ids"
-			cursor = idscan[0]
-			idscan[1].each do |x| # for each other-id 
 				# if they have a SIF local id value and a OneRoster id value that are the same, then we have identified
 				# a match between their corresponding guids
-#puts ">> #{x} " + @redis.hgetall(x).to_s 
+
 				
 				match = @redis.hmget x, 'oneroster_identifier', 'oneroster_userId', 'oneroster_courseCode', 'oneroster_classCode', 'localid'
 				#puts x + ': ' + match.join(',')
@@ -78,38 +79,29 @@ loop do
 					puts "\nParser Index = #{idx.to_json}\n\n"
                         		outbound_messages << Poseidon::MessageToSend.new( "#{@outbound}", idx.to_json, "indexed" )
 				end
+
 			end
+
+
+			# send results to indexer to create sms data graph
+	        outbound_messages.each_slice(20) do | batch |
+	                @pool.next.send_messages( batch )
+	        end
+
+		rescue Poseidon::Errors::UnknownTopicOrPartition
+			puts "Topic #{@outbound} does not exist yet."
 		end
+  	
+  	end
 
-		# send results to indexer to create sms data graph
-                outbound_messages.each_slice(20) do | batch |
-                        @pool.next.send_messages( batch )
-                end
-
-
-
-
-      # puts "cons-sms-indexer:: Resuming message consumption from: #{consumer.next_offset}"
-
-  rescue Poseidon::Errors::UnknownTopicOrPartition
-    puts "Topic #{@outbound} does not exist yet, will retry in 30 seconds"
-    sleep 30
-  end
-  
-  # puts "Resuming message consumption from: #{consumer.next_offset}"
-
-  # trap to allow console interrupt
-  trap("INT") { 
-    puts "\n#{@servicename} service shutting down...\n\n"
-    exit 130 
-  } 
-
-  sleep 1
-  
 end
 
 
+# test script - assumes OR and SIF data in db
 
+# orsm = OneRosterSifMerge.new
+
+# orsm.merge_ids
 
 
 

--- a/sms/services/cons-oneroster-sms-storage.rb
+++ b/sms/services/cons-oneroster-sms-storage.rb
@@ -43,16 +43,16 @@ loop do
 			idx = { :type => nil, :id => @idgen.encode( rand(1...999) ) }
 
       		# read JSON message
-                idx_hash = JSON.parse( m.value )
+            idx_hash = JSON.parse( m.value )
 
-		# type of converted CSV One Roster record depends on presence of particular field
-		idx[:type] = 'oneroster_orgs' if idx_hash.has_key?("metadata.boarding")
-		idx[:type] = 'oneroster_users' if idx_hash.has_key?("username")
-		idx[:type] = 'oneroster_courses' if idx_hash.has_key?("courseCode")
-		idx[:type] = 'oneroster_classes' if idx_hash.has_key?("classCode")
-		idx[:type] = 'oneroster_enrollments' if idx_hash.has_key?("primary")
-		idx[:type] = 'oneroster_academicSessions' if idx_hash.has_key?("startDate")
-		idx[:type] = 'oneroster_demographics' if idx_hash.has_key?("sex")
+			# type of converted CSV One Roster record depends on presence of particular field
+			idx[:type] = 'oneroster_orgs' if idx_hash.has_key?("metadata.boarding")
+			idx[:type] = 'oneroster_users' if idx_hash.has_key?("username")
+			idx[:type] = 'oneroster_courses' if idx_hash.has_key?("courseCode")
+			idx[:type] = 'oneroster_classes' if idx_hash.has_key?("classCode")
+			idx[:type] = 'oneroster_enrollments' if idx_hash.has_key?("primary")
+			idx[:type] = 'oneroster_academicSessions' if idx_hash.has_key?("startDate")
+			idx[:type] = 'oneroster_demographics' if idx_hash.has_key?("sex")
 
 			idx[:id] = idx[:type] == 'oneroster_demographics' ? idx_hash["userSourcedId"] :  idx_hash["sourcedId"]
 

--- a/sms/sms_query_server.rb
+++ b/sms/sms_query_server.rb
@@ -66,6 +66,7 @@ require 'csv'
 require 'moneta'
 
 require_relative 'sms_query'
+require_relative 'oneroster_sif_merge'
 
 
 class SMSQueryServer < Sinatra::Base
@@ -198,7 +199,19 @@ class SMSQueryServer < Sinatra::Base
 	end
 
 
+	get "/sms/merge_ids" do
+	
+		orsm = OneRosterSifMerge.new
 
+		begin
+			orsm.merge_ids
+		rescue 
+			return 500, 'Error executing SIF OneRoster id merge.'
+		end
+
+		return 200, 'SIF - OneRoster id merge complete'
+
+	end
 
 
 

--- a/sms/sms_visualise_query.rb
+++ b/sms/sms_visualise_query.rb
@@ -9,7 +9,7 @@ class SMSVizQuery
 
 	def initialize
                 @redis = Redis.new(:url => 'redis://localhost:6381', :driver => :hiredis)
-                @hashid = Hashids.new( 'nsip timesheeting' )
+                @hashid = Hashids.new( 'nsip sms_visualise_query' )
                 @expiry_seconds = 120 #update this for production
                 @rand_space = 10000
         end

--- a/sms/views/collections.erb
+++ b/sms/views/collections.erb
@@ -1,9 +1,10 @@
 <!-- collections.erb -->
 
+<% content_for :title do %>
+      <title>NIAS SMS: SIF Memory Store</title>
+<% end %>
 
 <div class="container">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js" charset="utf-8"></script>
-  <script src="http://dimplejs.org/dist/dimple.v2.1.6.min.js"></script>
   
 	<!-- header -->
     <section class="header">
@@ -57,116 +58,43 @@
 				</div>	
     		</div>
     	</div>
-
 	</div>
 
     <!-- lightweight query interface -->
     <div class="docs-section" id="query_ui"> 
 		<h6 class="docs-header">Query Explorer</h6>
-
-        <div> 
-            <!-- <form> -->
             <div class="row">
-                <div class="six columns">
-                    <label for="collections1">From Collection -> </label>
-                    <select class="u-full-width" id="collections1">
-                        <% @coll_result.sort! %>
-                        <% @coll_result.each do | collection | %>
-                            <option value="<%= collection %>"><%= collection %></option>    
-                        <% end %>
-                    </select>
-                </div>
-                <div class="six columns">
-                    <label for="item">Item</label>
-                    <select class="u-full-width" id="item">
-                        <!-- selector has no values until collection is chosen to select an item from -->
-                    </select>
-                </div>
+
+            <div class="six columns">
+                <label for="collections1">( From Collection... )</label>
+                <select class="u-full-width" id="collections1">
+                    <% @coll_result.sort! %>
+                    <% @coll_result.each do | collection | %>
+                        <option value="<%= collection %>"><%= collection %></option>    
+                    <% end %>
+                </select>
+
+                <label for="item">Item</label>
+                <select class="u-full-width" id="item">
+                    <!-- selector has no values until collection is chosen to select an item from -->
+                </select>
+
+                <label for="collections2">Relationship Collection</label>
+                <select class="u-full-width" id="collections2">
+                    <% @coll_result.sort! %>
+                    <% @coll_result.each do | collection | %>
+                        <option value="<%= collection %>"><%= collection %></option>    
+                    <% end %>
+                </select>
+
+                <button class="button-primary" id="query">Run Query</button>                                
             </div>
 
-            <div class="row">
-                <div class="six columns"><br/></div>
-                <div class="six columns">
-                    <label for="collections2">Relationship Collection</label>
-                    <select class="u-full-width" id="collections2">
-                        <% @coll_result.sort! %>
-                        <% @coll_result.each do | collection | %>
-                            <option value="<%= collection %>"><%= collection %></option>    
-                        <% end %>
-                    </select>
-                </div>
+            <div class="six columns">
+                <div id="chartContainer"></div>
             </div>
 
-            <div class="row">
-                <div class="six columns"><br/></div>                
-                <div class="six columns">
-                    <!-- <label for="query">Query</label> -->
-                    <!-- <input class="button-primary" type="submit" value="Query"> -->
-                    <button class="button-primary" id="query">Run Query</button>                                
-                </div>
-            </div>
-
-            <!-- handler for collection-to-find-an-item selector -->
-            <script>
-                // force user to choose a collection
-                $("#collections1 option:first").before( $('<option>',{value: 0,text: ''}));
-                
-                $("#collections1").change(function () {
-                    $("#item").find("option:gt(0)").remove();
-                    $("#item").find("option:first").text("Loading...");
-                    $.getJSON("/sms/find", {
-                        collection: $(this).val()
-                    }, function (json) {
-                        $("#item").find("option:first").text("");
-                        for (var i = 0; i < json.length; i++) {
-                            $("<option/>").attr("value", json[i].id).text(json[i].id).appendTo($("#item"));
-                        }
-                    });
-                });
-
-		$("#item").change(function() {
-                    var item = $("#item :selected").text();
-var mydiv = document.getElementById("chartContainer");
-//while ( mydiv.firstChild ) mydiv.removeChild( mydiv.firstChild );
-    	var svg = dimple.newSvg("#chartContainer", "600px", "200px");
-    	d3.json("/graph_data/linked_collections?id="+ item, function (data) {
-      	var myChart = new dimple.chart(svg, data);
-  	//myChart.setBounds(20, 20, 460, 360)
-      	myChart.addMeasureAxis("p", "data");
-      	var ring = myChart.addSeries("collection", dimple.plot.pie);
-      	ring.innerRadius = "50%";
-      	myChart.addLegend(400, 20, 90, 300, "left");
-      		myChart.draw();
-	});
-		});
-
-                $("#query").click(function(){
-
-                    var collection = $("#collections2").val();
-                    var item = $("#item :selected").text();
-                    var request = {};
-
-                    request.collection = collection;
-                    request.include_messages = true;
-                    request.id = item;
-
-		    
-                    $("#results").empty();
-                    $.getJSON("/sms/find", request, function(result){
-                        $.each(result, function(i, field){
-                            $("#results").append( field.id + "<br/><br/>" + field.data + "<br/><br/>");
-                        });
-                    });
-                });
-
-
-            </script>
-
-        <!-- </form> -->
         </div>
-
-	<div id="chartContainer" />
-
 
         <div class="row">
             <div class="twelve columns">
@@ -178,13 +106,63 @@ var mydiv = document.getElementById("chartContainer");
                 <!-- </pre>  -->
             </div>
         </div>
-	
+
+        <!-- handler for collection-to-find-an-item selector -->
+        <script>
+            // force user to choose a collection
+            $("#collections1 option:first").before( $('<option>',{value: 0,text: ''}));
+            
+            $("#collections1").change(function () {
+                $("#item").find("option:gt(0)").remove();
+                $("#item").find("option:first").text("Loading...");
+                $.getJSON("/sms/find", {
+                    collection: $(this).val()
+                }, function (json) {
+                    $("#item").find("option:first").text("");
+                    for (var i = 0; i < json.length; i++) {
+                        $("<option/>").attr("value", json[i].id).text(json[i].id).appendTo($("#item"));
+                    }
+                });
+            });
+
+    		$("#item").change(function() {
+
+                var item = $("#item :selected").text();
+                $("#chartContainer").empty();
+
+                var svg = dimple.newSvg("#chartContainer", "100%", "200px");
+                
+                d3.json("/graph_data/linked_collections?id="+ item, function (data) {
+                    var myChart = new dimple.chart(svg, data);
+                    myChart.setBounds("20%", "10%", "60%", "80%")
+                    myChart.addMeasureAxis("x", "data");
+                    myChart.addCategoryAxis("y", "collection");
+                    var ring = myChart.addSeries("collection", dimple.plot.bar);
+                    myChart.draw();
+                });
+            });
+
+            $("#query").click(function(){
+
+                var collection = $("#collections2").val();
+                var item = $("#item :selected").text();
+                var request = {};
+
+                request.collection = collection;
+                request.include_messages = true;
+                request.id = item;
+
+	    
+                $("#results").empty();
+                $.getJSON("/sms/find", request, function(result){
+                    $.each(result, function(i, field){
+                        $("#results").append( field.id + "<br/><br/>" + field.data + "<br/><br/>");
+                    });
+                });
+            });
+
+        </script>
     </div>
-
-
-<!-- <textarea class="u-full-width" placeholder="Query Results..." id="results"></textarea> -->
-
-
 
 </div>
 

--- a/sms/views/las.erb
+++ b/sms/views/las.erb
@@ -41,10 +41,10 @@
 				<div id="dashboardchart1">
 					<h6>Average absences per class</h6>
 					<script>
-				        var svg1 = dimple.newSvg("#dashboardchart1", "100%", "400px");
+				        var svg1 = dimple.newSvg("#dashboardchart1", "100%", "500px");
 				        d3.json("/graph_data/attendance_per_class", function (data) {
 				        var myChart = new dimple.chart(svg1, data);
-				        //myChart.setBounds(20, 20, 460, 360)
+				        myChart.setBounds("5%", "5%", "100%", "70%")
 				        var x = myChart.addCategoryAxis("x", "class");
 				        myChart.addMeasureAxis("y", "average absences");
 				        myChart.addSeries(null, dimple.plot.bar);
@@ -63,10 +63,10 @@
 				<div id="dashboardchart2">
 					<h6>Most absent students</h6>
 					<script>
-				        var svg2 = dimple.newSvg("#dashboardchart2", "100%", "400px");
+				        var svg2 = dimple.newSvg("#dashboardchart2", "100%", "500px");
 				        d3.json("/graph_data/most_absent_students", function (data) {
 				        var myChart = new dimple.chart(svg2, data);
-				        //myChart.setBounds(20, 20, 460, 360)
+				        myChart.setBounds("5%", "5%", "100%", "70%")
 				        var x = myChart.addCategoryAxis("x", "student");
 				        myChart.addMeasureAxis("y", "absences");
 				        myChart.addSeries(null, dimple.plot.bar);

--- a/test_data/seq.sh
+++ b/test_data/seq.sh
@@ -12,5 +12,8 @@ http post :9292/test/test1 Content-Type:application/xml < studentcontactrelation
 http post :9292/test/test1 Content-Type:application/xml < studentcontactpersonals.xml
 
 http post :9292/oneroster/validated Content-Type:text/csv < usersfromsif.csv
-http post :9292/oneroster/validated Content-Type:text/csv < classes.csv
-http post :9292/oneroster/validated Content-Type:text/csv < enrollments.csv
+# http post :9292/oneroster/validated Content-Type:text/csv < classes.csv
+# http post :9292/oneroster/validated Content-Type:text/csv < enrollments.csv
+
+http get :9292/sms/merge_ids
+


### PR DESCRIPTION
Some tidy ups on graph views, have changed relationship graph to bar
chart to make easier to read.

OneRoster merge service uses scan in a loop - scan is a weird function
and never completes in the loop because the db is changing as a result
of what it is doing, so goes recursive.

Have refactored out to a standalone class that can be called via an
/sms endpoint - /sms/merge_ids, which does the work on demand

Call at the end of the seq. shell script and all works fine.
